### PR TITLE
fixed json default parameter in run function

### DIFF
--- a/R/mongo.R
+++ b/R/mongo.R
@@ -267,7 +267,7 @@ mongo_object <- function(col, client, verbose, orig){
       orig
     }
 
-    run <- function(command = '{"ping: 1}'){
+    run <- function(command = '{"ping": 1}'){
       mongo_collection_command_simple(col, command)
     }
 


### PR DESCRIPTION
In line 270 of /R/mongo.R the default parameter for the `run` function was an invalid json.

```
run <- function(command = '{"ping: 1}'){
      mongo_collection_command_simple(col, command)
}
```
Fixed it by adding a `"` at the end of the key `ping`