### PR TITLE
Moves to canonical extended JSON output

### DIFF
--- a/src/bson.c
+++ b/src/bson.c
@@ -44,7 +44,7 @@ SEXP R_raw_to_bson(SEXP buf){
 }
 
 SEXP R_bson_to_json(SEXP ptr){
-  return mkStringUTF8(bson_as_json (r2bson(ptr), NULL));
+  return mkStringUTF8(bson_as_canonical_extended_json (r2bson(ptr), NULL));
 }
 
 SEXP R_bson_to_raw(SEXP ptr){

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -67,7 +67,7 @@ SEXP R_mongo_cursor_next_json (SEXP ptr, SEXP n){
         break;
     } else {
       size_t jsonlength;
-      char *str = bson_as_json ((bson_t*) b, &jsonlength);
+      char *str = bson_as_canonical_extended_json ((bson_t*) b, &jsonlength);
       SET_STRING_ELT(out, total, mkCharLenCE(str, jsonlength, CE_UTF8));
       if(str) bson_free(str);
       total++;

--- a/src/utils.c
+++ b/src/utils.c
@@ -16,7 +16,7 @@ SEXP bson_to_str(const bson_t * b){
   if(b == NULL)
     return ScalarString(NA_STRING);
   size_t jsonlength;
-  char *str = bson_as_json(b, &jsonlength);
+  char *str = bson_as_canonical_extended_json(b, &jsonlength);
   if(str == NULL)
     return ScalarString(NA_STRING);
   SEXP out = ScalarString(mkCharLenCE(str, jsonlength, CE_UTF8));


### PR DESCRIPTION
As discussed in jeroen/jsonlite#247, `mongolite` is currently producing so-called "legacy" extended JSON in some places. This commit moves existing uses of `bson_as_json()` to `bson_as_canonical_extended_json()` in an effort to resolve this.