### PR TITLE
Avoid memory leak within `R_mongo_get_default_database`

### DIFF
--- a/src/collection.c
+++ b/src/collection.c
@@ -11,7 +11,9 @@ SEXP R_mongo_get_default_database(SEXP ptr_client) {
   mongoc_client_t *client = r2client(ptr_client);
   mongoc_database_t *db = mongoc_client_get_default_database(client);
   if(db){
-    return Rf_mkString(mongoc_database_get_name(db));
+    SEXP out = Rf_mkString(mongoc_database_get_name(db));
+    mongoc_database_destroy(db);
+    return out;
   } else {
     return R_NilValue;
   }


### PR DESCRIPTION
According to https://s3.amazonaws.com/mciuploads/mongo-c-driver/docs/latest/mongoc_client_get_default_database.html allocated memory needs to be cleaned-up with `mongoc_database_destroy`.

Adds the proper call to avoid a memory leak.