### PR TITLE
Avoid memory leak within `R_mongo_collection_find`

### DIFF
--- a/src/collection.c
+++ b/src/collection.c
@@ -173,8 +173,7 @@ SEXP R_mongo_collection_find(SEXP ptr_col, SEXP ptr_query, SEXP ptr_opts) {
   mongoc_collection_t *col = r2col(ptr_col);
   bson_t *query = r2bson(ptr_query);
   bson_t *opts = r2bson(ptr_opts);
-  mongoc_read_prefs_t * readpref = mongoc_read_prefs_new(MONGOC_READ_PRIMARY);
-  mongoc_cursor_t *c = mongoc_collection_find_with_opts(col, query, opts, readpref);
+  mongoc_cursor_t *c = mongoc_collection_find_with_opts(col, query, opts, NULL);
   return cursor2r(c, ptr_col);
 }
 


### PR DESCRIPTION
`R_mongo_collection_find` leaks memory as `mongoc_read_prefs_new(MONGOC_READ_PRIMARY)` is not cleaned up.
Anyway, `MONGOC_READ_PRIMARY` is the default (http://mongoc.org/libmongoc/current/mongoc_read_prefs_t.html).
This patch avoids the leakage by not allocating the memory in the first place but instead using `NULL` for `mongoc_collection_find_with_opts` to use the default values.