### PR TITLE
Call mongoc_handshake_data_append

### DIFF
--- a/src/mongo_log.c
+++ b/src/mongo_log.c
@@ -1,4 +1,5 @@
 #include <R_ext/Rdynload.h>
+#include <Rversion.h>
 #include <mongolite.h>
 
 //default
@@ -32,10 +33,18 @@ void mongolite_log_handler (mongoc_log_level_t event, const char *log_domain, co
 
 void R_init_mongolite(DllInfo *info) {
   static mongoc_log_func_t logfun = mongolite_log_handler;
+  char *r_version;
   mongoc_init();
+#if defined (R_VERSION)
+  r_version = bson_strdup_printf ("R=%s.%s ", R_MAJOR, R_MINOR);
+#else
+  r_version = bson_strdup ("R=undefined ");
+#endif
+  mongoc_handshake_data_append ("mongolite", "", r_version);
   mongoc_log_set_handler(logfun, NULL);
   R_registerRoutines(info, NULL, NULL, NULL, NULL);
   R_useDynamicSymbols(info, TRUE);
+  bson_free (r_version);
 }
 
 void R_unload_mongolite(DllInfo *info) {


### PR DESCRIPTION
**Summary**
Calls the libmongoc function `mongoc_handshake_data_append` to add additional metadata to the connection handshake to identify wrapping drivers.

**Motivation**
The MongoDB driver handshake specification [Supporting Wrapping Libraries](https://github.com/mongodb/specifications/blob/3da2c7816f6cdb449bd22603523c2dfc4b0af3e9/source/mongodb-handshake/handshake.rst#supporting-wrapping-libraries) defines an API for wrapping libraries to identify themselves. `mongoc_handshake_data_append` is utilized by the [MongoDB PHP driver](https://github.com/mongodb/mongo-php-driver/blob/45dd0dffc8c33f26ebc1db8a55f690c17818cf98/php_phongo.c#L2490:L2490) and [MongoDB C++ driver](https://github.com/kevinAlbs/mongo-cxx-driver/blob/33416f88f1d59e19eb103fedab59d73399332a7c/src/mongocxx/instance.cpp#L93:L93).

I am new to R. I was able to build and install locally with:
```
R CMD BUILD mongolite
R CMD INSTALL mongolite_2_3_1.tar.gz
```

I tested this by opening a connection with:
```
library(mongolite)
m <- mongo()
```

I observed the logs of a local running mongod to see the difference in the handshake metadata.

Before this change:
```
{"t":{"$date":"2021-08-23T11:56:25.010-04:00"},"s":"I",  "c":"NETWORK",  "id":51800,   "ctx":"conn1073","msg":"client metadata","attr":{"remote":"127.0.0.1:60575","client":"conn1072","doc":{"application":{"name":"r/mongolite"},"driver":{"name":"mongoc","version":"1.16.2"},"os":{"type":"Darwin","name":"macOS","version":"20.5.0","architecture":"x86_64"},"platform":"cfg=0x000216aa65 posix=200112 stdc=201710 CC=clang 12.0.5 (clang-1205.0.22.11) CFLAGS=\"\" LDFLAGS=\"\""}}}
```

After this change:

```
{"t":{"$date":"2021-08-23T12:15:27.444-04:00"},"s":"I",  "c":"NETWORK",  "id":51800,   "ctx":"conn1074","msg":"client metadata","attr":{"remote":"127.0.0.1:61003","client":"conn1074","doc":{"application":{"name":"r/mongolite"},"driver":{"name":"mongoc / mongolite","version":"1.16.2 / "},"os":{"type":"Darwin","name":"macOS","version":"20.5.0","architecture":"x86_64"},"platform":"R=4.1.1 cfg=0x000216aa65 posix=200112 stdc=201710 CC=clang 12.0.5 (clang-1205.0.22.11) CFLAGS=\"\" LDFLAGS=\"\""}}}
```

