### PR TITLE
Do not set appname if set in URI

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -49,7 +49,9 @@ SEXP R_mongo_client_new(SEXP uri_string, SEXP pem_file, SEXP pem_pwd, SEXP ca_fi
     mongoc_client_set_ssl_opts(client, &opt);
   }
 
-  mongoc_client_set_appname (client, "r/mongolite");
+  if (NULL == mongoc_uri_get_appname (uri)) {
+    mongoc_client_set_appname (client, "r/mongolite");
+  }
 
 #endif
 


### PR DESCRIPTION
**Summary**
Only call `mongoc_client_set_appname` if the `appname` URI option is not set.

**Motivation**

`appname` is a URI option users may set themselves: https://docs.mongodb.com/manual/reference/connection-string/#miscellaneous-configuration

Before this change:

Attempting to set the `appname` in the URI results in a warning:

```
> m <- mongo(url="mongodb://localhost:27017/?appname=foo")
Warning: [ERROR] Cannot set appname more than once
```

The appname set in the URI is applied first. Observing `mongod` logs of the handshake shows `application.name` is `foo`. 

```
{"t":{"$date":"2021-08-28T14:51:26.131-04:00"},"s":"I",  "c":"NETWORK",  "id":51800,   "ctx":"conn8307","msg":"client metadata","attr":{"remote":"127.0.0.1:60929","client":"conn8307","doc":{"application":{"name":"foo"},"driver":{"name":"mongoc","version":"1.16.2"},"os":{"type":"Darwin","name":"macOS","version":"20.5.0","architecture":"x86_64"},"platform":"cfg=0x000216aa65 posix=200112 stdc=201710 CC=clang 12.0.5 (clang-1205.0.22.11) CFLAGS=\"\" LDFLAGS=\"\""}}}
```

After this change:

No warning is reported by mongolite.

**Rejected Alternatives**

Alternativly, the call to `mongoc_client_set_appname (client, "r/mongolite");` could be removed entirely since `appname` is not intended to be set by a driver.

However, removing the call could cause friction on users that are tracking `mongolite` clients through the existing `r/mongolite` appname.
