### PR TITLE
Replace md5 with sha1 to ensure FIPS compliance

### DIFF
--- a/R/pool.R
+++ b/R/pool.R
@@ -5,7 +5,7 @@
 new_client <- local({
   pool <- new.env()
   function(params){
-    hash <- as.character(openssl::md5(serialize(params, NULL)))
+    hash <- as.character(openssl::sha1(serialize(params, NULL)))
     client <- get_weakref(pool[[hash]])
     if(!length(client) || null_ptr(client)){
       # Make sure 'client' remains in scope after creating weakref!


### PR DESCRIPTION
FIPS compliance requires that some insecure crypto algorithms are disabled - md5 is one of these non-compliant algorithms. Using the sha1 algorithm in place of md5 for the internal pool function retains hash map functionality while also allowing FIPS compliant systems to utilize mongolite.